### PR TITLE
[ConfigFix] Specify PyYAML version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(name='glusto',
             'glusto = glusto.main:main',
             ]
                     },
-      install_requires=['plumbum', 'rpyc', 'PyYAML', 'jinja2',
+      install_requires=['plumbum', 'rpyc', 'PyYAML==5.4.1', 'jinja2',
                         'pytest', 'nose', 'unittest-xml-reporting']
       )


### PR DESCRIPTION
[Problem]
With the latest version of pyYAML [> 5.4.1], the
`yaml.load(f)` is deprecated in favour of
`yaml.load(f, Loader=loader)`. This causes
"""
File "/usr/local/lib/python3.6/site-packages/glusto/configurable.py", line 215, in _load_yaml
config = yaml.load(configfd)
TypeError: load() missing 1 required positional argument: 'Loader' """
More discussion on this topic [1]

[1] https://github.com/yaml/pyyaml/issues/576

[Solution]
Fix the version to 5.4.1 as changing the code to accomodate
the latest method changes requires further testing.

Signed-off-by: Pranav <prprakas@redhat.com>